### PR TITLE
v0.1.0-alpha.9

### DIFF
--- a/raspi-setup/pyproject.toml
+++ b/raspi-setup/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hermes-raspi-setup"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 description = ""
 authors = ["Moritz Makowski <moritz.makowski@tum.de>"]
 readme = "README.md"

--- a/sensor/config/config.template.json
+++ b/sensor/config/config.template.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.0-alpha.8",
+    "version": "0.1.0-alpha.9",
     "revision": 0,
     "verbose_logging": false,
     "active_components": {

--- a/sensor/pyproject.toml
+++ b/sensor/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sensor"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 description = ""
 authors = ["Moritz Makowski <moritz.makowski@tum.de>"]
 readme = "README.md"

--- a/sensor/src/custom_types/config.py
+++ b/sensor/src/custom_types/config.py
@@ -235,7 +235,7 @@ class HeatedEnclosureConfig(BaseModel):
 class Config(BaseModel):
     """The config.json for each sensor"""
 
-    version: Literal["0.1.0-alpha.8"]
+    version: Literal["0.1.0-alpha.9"]
     revision: int
     verbose_logging: bool
     active_components: ActiveComponentsConfig
@@ -246,7 +246,7 @@ class Config(BaseModel):
 
     # validators
     _val_version = validator("version", pre=True, allow_reuse=True)(
-        validate_str(allowed=["0.1.0-alpha.8"]),
+        validate_str(allowed=["0.1.0-alpha.9"]),
     )
     _val_revision = validator("revision", pre=True, allow_reuse=True)(
         validate_int(minimum=0, maximum=2_147_483_648),


### PR DESCRIPTION
- [ ] Only test `config.json` when code version doesn't change
- [ ] Do not send empty details on log messages
- [ ] Figure out why poetry takes 5 minutes to install packages even when they should be cached locally