### PR TITLE
Move start pump in class init

### DIFF
--- a/sensor/src/hardware/pump.py
+++ b/sensor/src/hardware/pump.py
@@ -75,6 +75,15 @@ class PumpInterface:
             self.rps_monitoring_process.start()
 
         # ---------------------------------------------------------------------
+        # start pump to run continuously
+        
+        self.set_desired_pump_speed(
+            unit="litres_per_minute",
+            value=self.config.measurement.timing.pumped_litres_per_minute,
+        )
+        time.sleep(0.5)
+        
+        # ---------------------------------------------------------------------
 
         self.logger.info("Finished initialization")
 

--- a/sensor/src/procedures/measurement.py
+++ b/sensor/src/procedures/measurement.py
@@ -23,13 +23,6 @@ class MeasurementProcedure:
         self.last_measurement_time: float = 0
         self.message_queue = utils.MessageQueue()
 
-        # set up pump to run continuously
-        self.hardware_interface.pump.set_desired_pump_speed(
-            unit="litres_per_minute",
-            value=self.config.measurement.timing.pumped_litres_per_minute,
-        )
-        time.sleep(0.5)
-
     def _update_air_inlet_parameters(self) -> None:
         """
         1. fetches the latest temperature and pressure data at air inlet


### PR DESCRIPTION
After the hardware reinitialize, the pump wasn't started again. The reason for this is that beta.3 isn't calling it before every measurement but only starts it up in the measurement procedure class init. 

With moving it to the pump init it will be initialized also after a teardown. 