### PR TITLE
fixed a validation-error for valid names, which caused server-CI to fail

### DIFF
--- a/server/tests/test_validation.py
+++ b/server/tests/test_validation.py
@@ -45,7 +45,7 @@ def test_validate_type_name_fail(value):
         pydantic.TypeAdapter(validation.types.Name).validate_python(value)
 
 
-@pytest.mark.parametrize("value", ["x", "x_x", "x_x_x", "x" * 64, "abc", "example_abc"])
+@pytest.mark.parametrize("value", ["x", "x_x", "x_x_x", "x" * 64, "abc", "example_abc", "example_123"])
 def test_validate_type_key_pass(value):
     pydantic.TypeAdapter(validation.types.Key).validate_python(value)
 
@@ -71,7 +71,7 @@ def test_validate_type_key_pass(value):
         '"',
         ".;",
         "12345678",
-        "example_123",
+        "12example_123",
     ],
 )
 def test_validate_type_key_fail(value):

--- a/server/tests/test_validation.py
+++ b/server/tests/test_validation.py
@@ -10,7 +10,7 @@ import app.validation as validation
 
 
 @pytest.mark.parametrize(
-    "value", ["x", "x-x", "x-x-x", "x" * 64, "12345678", "example", "12345678-abc"]
+    "value", ["x", "x-x", "x-x-x", "x" * 64, "example"]
 )
 def test_validate_type_name_pass(value):
     pydantic.TypeAdapter(validation.types.Name).validate_python(value)
@@ -36,6 +36,8 @@ def test_validate_type_name_pass(value):
         "饭",
         '"',
         ".;",
+        "12345678",
+        "12345678-abc",
     ],
 )
 def test_validate_type_name_fail(value):


### PR DESCRIPTION
This fixes a CI-failure caused by a name-validation error due to incorrect test-values provided in the CI-test.