### PR TITLE
Feature/simulate sensor node

### DIFF
--- a/sensor/docker/Dockerfile
+++ b/sensor/docker/Dockerfile
@@ -1,5 +1,5 @@
 # using base-image containing python3.9, setting shell to use bash by default, switching to /root folder
-FROM python:3.9
+FROM python:3.9 as build_image
 SHELL ["/bin/bash", "-c"]
 WORKDIR /root
 
@@ -10,7 +10,7 @@ RUN apt install -y jq moreutils
 # install poetry and set up a venv
 RUN python3.9 -m pip install --upgrade pip
 RUN python3.9 -m pip install poetry
-RUN python3.9 -m venv .venv
+RUN python3.9 -m venv --copies .venv
 RUN source .venv/bin/activate
 
 COPY poetry.lock .
@@ -21,18 +21,25 @@ COPY README.md .
 RUN poetry config installer.max-workers 1
 RUN poetry install --with=dev
 
+COPY config ./config
+COPY config/config.template.json ./config/config.json
+
+RUN echo 'HERMES_HARDWARE_LOCKFILE_PATH="/root/hermes_hardware.lock"' > ./config/.env
+
+FROM python:3.9-slim
+
+WORKDIR /root
+COPY --from=build_image /root/.venv /root/.venv
+
 # copy source directories
 COPY cli ./cli
-COPY config ./config
 COPY data ./data
 COPY logs ./logs
 COPY scripts ./scripts
 COPY src ./src
 COPY tests ./tests
+COPY --from=build_image /root/config ./config
 
 COPY run_automation.py .
-COPY config/config.template.json ./config/config.json
 
-RUN echo 'HERMES_HARDWARE_LOCKFILE_PATH="/root/hermes_hardware.lock"' > ./config/.env
-
-ENTRYPOINT ["/root/.venv/bin/python3.9", "/root/run_automation.py"]
+ENTRYPOINT ["/root/.venv/bin/python3", "/root/run_automation.py"]

--- a/sensor/docker/Dockerfile
+++ b/sensor/docker/Dockerfile
@@ -19,7 +19,7 @@ COPY README.md .
 
 # install dependencies through poetry
 RUN poetry config installer.max-workers 1
-RUN poetry install --with=dev
+RUN poetry install --no-root
 
 COPY config ./config
 COPY config/config.template.json ./config/config.json

--- a/sensor/docker/docker_run.sh
+++ b/sensor/docker/docker_run.sh
@@ -8,6 +8,7 @@ export HERMES_DEPLOYMENT_ROOT_PATH=/root/deployment
 # Run the docker image
 docker run -it --rm --name hermes_sensor \
   --env-file .env \
+  -e HERMES_MQTT_IDENTIFIER="$HERMES_MQTT_IDENTIFIER" \
   -e HERMES_DEPLOYMENT_ROOT_PATH="$HERMES_DEPLOYMENT_ROOT_PATH" \
   -v "$GLOBAL_HERMES_DEPLOYMENT_ROOT_PATH":"$HERMES_DEPLOYMENT_ROOT_PATH" \
   tum-esm/hermes/sensor

--- a/sensor/src/hardware/__init__.py
+++ b/sensor/src/hardware/__init__.py
@@ -38,9 +38,10 @@ class HardwareInterface:
         is used by another process"""
 
     def __init__(
-            self,
-            config: custom_types.Config,
-            testing: bool = False,
+        self,
+        config: custom_types.Config,
+        testing: bool = False,
+        simulate: bool = False,
     ) -> None:
         global_hw_lock["lock"] = filelock.FileLock(
             os.environ.get("HERMES_HARDWARE_LOCKFILE_PATH") or "/home/pi/Documents/hermes/hermes-hardware.lock",
@@ -53,25 +54,26 @@ class HardwareInterface:
             write_to_file=(not testing),
         )
         self.testing = testing
+        self.simulate = simulate
         acquire_hardware_lock()
 
         # measurement sensors
-        self.wind_sensor = WindSensorInterface(config, testing=self.testing)
+        self.wind_sensor = WindSensorInterface(config, testing=self.testing, simulate=self.simulate)
         self.air_inlet_bme280_sensor = BME280SensorInterface(
-            config, variant="air-inlet", testing=self.testing
+            config, variant="air-inlet", testing=self.testing, simulate=self.simulate
         )
-        self.air_inlet_sht45_sensor = SHT45SensorInterface(config, testing=self.testing)
-        self.co2_sensor = CO2SensorInterface(config, testing=self.testing)
+        self.air_inlet_sht45_sensor = SHT45SensorInterface(config, testing=self.testing, simulate=self.simulate)
+        self.co2_sensor = CO2SensorInterface(config, testing=self.testing, simulate=self.simulate)
 
         # measurement actors
-        self.pump = PumpInterface(config, testing=self.testing)
-        self.valves = ValveInterface(config, testing=self.testing)
+        self.pump = PumpInterface(config, testing=self.testing, simulate=self.simulate)
+        self.valves = ValveInterface(config, testing=self.testing, simulate=self.simulate)
 
         # enclosure controls
         self.mainboard_sensor = BME280SensorInterface(
-            config, variant="mainboard", testing=self.testing
+            config, variant="mainboard", testing=self.testing, simulate=self.simulate
         )
-        self.ups = UPSInterface(config, testing=self.testing)
+        self.ups = UPSInterface(config, testing=self.testing, simulate=self.simulate)
 
     def check_errors(self) -> None:
         """checks for detectable hardware errors"""
@@ -111,18 +113,18 @@ class HardwareInterface:
 
         # measurement sensors
         self.air_inlet_bme280_sensor = BME280SensorInterface(
-            config, variant="air-inlet", testing=self.testing
+            config, variant="air-inlet", testing=self.testing, simulate=self.simulate
         )
-        self.air_inlet_sht45_sensor = SHT45SensorInterface(config, testing=self.testing)
-        self.co2_sensor = CO2SensorInterface(config, testing=self.testing)
-        self.wind_sensor = WindSensorInterface(config, testing=self.testing)
+        self.air_inlet_sht45_sensor = SHT45SensorInterface(config, testing=self.testing, simulate=self.simulate)
+        self.co2_sensor = CO2SensorInterface(config, testing=self.testing, simulate=self.simulate)
+        self.wind_sensor = WindSensorInterface(config, testing=self.testing, simulate=self.simulate)
 
         # measurement actors
-        self.pump = PumpInterface(config, testing=self.testing)
-        self.valves = ValveInterface(config, testing=self.testing)
+        self.pump = PumpInterface(config, testing=self.testing, simulate=self.simulate)
+        self.valves = ValveInterface(config, testing=self.testing, simulate=self.simulate)
 
         # enclosure controls
         self.mainboard_sensor = BME280SensorInterface(
-            config, variant="mainboard", testing=self.testing
+            config, variant="mainboard", testing=self.testing, simulate=self.simulate
         )
-        self.ups = UPSInterface(config, testing=self.testing)
+        self.ups = UPSInterface(config, testing=self.testing, simulate=self.simulate)

--- a/sensor/src/hardware/bme280_sensor.py
+++ b/sensor/src/hardware/bme280_sensor.py
@@ -25,8 +25,11 @@ class BME280SensorInterface:
         self.simulate = simulate
         self.logger.info("starting initialization")
         self.compensation_params: Optional[bme280.params] = None
-        self.simulate = simulate
         self.bus = None
+
+        if self.simulate:
+            self.sensor_connected = True
+            return
 
         # set up connection to BME280 sensor
         self.sensor_connected = False

--- a/sensor/src/hardware/bme280_sensor.py
+++ b/sensor/src/hardware/bme280_sensor.py
@@ -29,6 +29,7 @@ class BME280SensorInterface:
 
         if self.simulate:
             self.sensor_connected = True
+            self.logger.info("Simulating BME280 sensor.")
             return
 
         # set up connection to BME280 sensor

--- a/sensor/src/hardware/bme280_sensor.py
+++ b/sensor/src/hardware/bme280_sensor.py
@@ -131,9 +131,14 @@ class BME280SensorInterface:
             self.compensation_params = None
 
     def _reset_sensor(self) -> None:
+        if self.simulate:
+            self.sensor_connected = True
+            return
+        
         try:
             self.compensation_params = None
-            self.bus.close()
+            if self.bus:
+                self.bus.close()
             time.sleep(1)
             self.bus = smbus2.SMBus(1)
             self.address = 0x77 if (self.variant == "mainboard") else 0x76

--- a/sensor/src/hardware/bme280_sensor.py
+++ b/sensor/src/hardware/bme280_sensor.py
@@ -13,6 +13,7 @@ class BME280SensorInterface:
         config: custom_types.Config,
         variant: Literal["mainboard", "air-inlet"],
         testing: bool = False,
+        simulate: bool = False,
     ) -> None:
         self.logger = utils.Logger(
             "mainboard-bme280" if (variant == "mainboard") else "air-inlet-bme280",
@@ -21,8 +22,11 @@ class BME280SensorInterface:
         )
         self.config = config
         self.variant = variant
+        self.simulate = simulate
         self.logger.info("starting initialization")
         self.compensation_params: Optional[bme280.params] = None
+        self.simulate = simulate
+        self.bus = None
 
         # set up connection to BME280 sensor
         self.sensor_connected = False
@@ -59,6 +63,13 @@ class BME280SensorInterface:
 
     def get_data(self, retries: int = 1) -> custom_types.BME280SensorData:
         """Reads temperature,humidity and pressure on mainboard and air inlet"""
+
+        if self.simulate:
+            return custom_types.BME280SensorData(
+                temperature=20.0,
+                humidity=50.0,
+                pressure=1013.25,
+            )
 
         # initialize output
         output = custom_types.BME280SensorData(
@@ -143,4 +154,5 @@ class BME280SensorInterface:
 
     def teardown(self) -> None:
         """Ends all hardware/system connections"""
-        self.bus.close()
+        if self.bus:
+            self.bus.close()

--- a/sensor/src/hardware/co2_sensor.py
+++ b/sensor/src/hardware/co2_sensor.py
@@ -44,8 +44,8 @@ class CO2SensorInterface:
         self.logger.info("Starting initialization.")
         self.last_powerup_time: float = time.time()
 
-        if simulate:
-            self.logger.info("Finished simulated CO2 sensor initialization.")
+        if self.simulate:
+            self.logger.info("Simulating CO2 sensor.")
             return
 
         # power pin to power up/down CO2 sensor

--- a/sensor/src/hardware/co2_sensor.py
+++ b/sensor/src/hardware/co2_sensor.py
@@ -44,20 +44,23 @@ class CO2SensorInterface:
         self.logger.info("Starting initialization.")
         self.last_powerup_time: float = time.time()
 
-        if not simulate:
-            # power pin to power up/down CO2 sensor
-            self.pin_factory = utils.get_gpio_pin_factory()
-            self.power_pin = gpiozero.OutputDevice(
-                pin=CO2_SENSOR_POWER_PIN_OUT, pin_factory=self.pin_factory
-            )
+        if simulate:
+            self.logger.info("Finished simulated CO2 sensor initialization.")
+            return
 
-            # serial connection to receive data from CO2 sensor
-            self.serial_interface = utils.serial_interfaces.SerialCO2SensorInterface(
-                port=CO2_SENSOR_SERIAL_PORT
-            )
+        # power pin to power up/down CO2 sensor
+        self.pin_factory = utils.get_gpio_pin_factory()
+        self.power_pin = gpiozero.OutputDevice(
+            pin=CO2_SENSOR_POWER_PIN_OUT, pin_factory=self.pin_factory
+        )
 
-            # turn the sensor off and on and set it to our default settings
-            self._reset_sensor()
+        # serial connection to receive data from CO2 sensor
+        self.serial_interface = utils.serial_interfaces.SerialCO2SensorInterface(
+            port=CO2_SENSOR_SERIAL_PORT
+        )
+
+        # turn the sensor off and on and set it to our default settings
+        self._reset_sensor()
 
         self.logger.info("Finished initialization.")
 

--- a/sensor/src/hardware/co2_sensor.py
+++ b/sensor/src/hardware/co2_sensor.py
@@ -367,14 +367,17 @@ class CO2SensorInterface:
     def check_errors(self) -> None:
         """checks whether the CO2 probe reports any errors. Possibly raises
         the CO2SensorInterface.CommunicationError exception"""
-        if not self.simulate:
-            answer = self._send_command_to_sensor("errs")
+        if self.simulate:
+            self.logger.info("The CO2 sensor check doesn't report any errors.")
+            return
 
-            if not ("OK: No errors detected." in answer):
-                self.logger.warning(
-                    f"The CO2 sensor reported errors: {answer}",
-                    config=self.config,
-                )
+        answer = self._send_command_to_sensor("errs")
+
+        if not ("OK: No errors detected." in answer):
+            self.logger.warning(
+                f"The CO2 sensor reported errors: {answer}",
+                config=self.config,
+            )
 
         self.logger.info("The CO2 sensor check doesn't report any errors.")
 

--- a/sensor/src/hardware/pump.py
+++ b/sensor/src/hardware/pump.py
@@ -28,27 +28,29 @@ class PumpInterface:
         self.simulate = simulate
         self.logger.info("Starting initialization")
 
+        if self.simulate:
+            self.logger.info("Simulating pump.")
+            return
         # ---------------------------------------------------------------------
         # INITIALIZING THE PUMP CONTROL PIN
 
-        if not simulate:
-            # pin factory required for hardware PWM
-            self.pin_factory = utils.get_gpio_pin_factory()
+        # pin factory required for hardware PWM
+        self.pin_factory = utils.get_gpio_pin_factory()
 
-            # pins for setting desired pump speed
-            self.control_pin = gpiozero.PWMOutputDevice(
-                pin=PUMP_CONTROL_PIN_OUT,
-                active_high=True,
-                initial_value=0,
-                frequency=PUMP_CONTROL_PIN_FREQUENCY,
-                pin_factory=self.pin_factory,
-            )
+        # pins for setting desired pump speed
+        self.control_pin = gpiozero.PWMOutputDevice(
+            pin=PUMP_CONTROL_PIN_OUT,
+            active_high=True,
+            initial_value=0,
+            frequency=PUMP_CONTROL_PIN_FREQUENCY,
+            pin_factory=self.pin_factory,
+        )
 
-            # start pump to run continuously
-            self.set_desired_pump_speed(
-                pwm_duty_cycle=self.config.hardware.pump_pwm_duty_cycle,
-            )
-            time.sleep(0.5)
+        # start pump to run continuously
+        self.set_desired_pump_speed(
+            pwm_duty_cycle=self.config.hardware.pump_pwm_duty_cycle,
+        )
+        time.sleep(0.5)
 
         self.logger.info("Finished initialization")
 

--- a/sensor/src/hardware/sht45_sensor.py
+++ b/sensor/src/hardware/sht45_sensor.py
@@ -25,7 +25,7 @@ class SHT45SensorInterface:
         self.simulate = simulate
         self.logger.info("Starting initialization.")
 
-        if simulate:
+        if self.simulate:
             self.sensor_connected = True
             self.logger.info("Simulating SHT45 sensor.")
             return

--- a/sensor/src/hardware/sht45_sensor.py
+++ b/sensor/src/hardware/sht45_sensor.py
@@ -1,3 +1,4 @@
+import random
 import time
 
 import adafruit_sht4x
@@ -21,11 +22,11 @@ class SHT45SensorInterface:
             write_to_file=(not testing),
         )
         self.config = config
-
+        self.simulate = simulate
         self.logger.info("Starting initialization.")
 
         if simulate:
-            self.sensor_connected = False
+            self.sensor_connected = True
             self.logger.info("Simulating SHT45 sensor.")
             return
 
@@ -60,6 +61,12 @@ class SHT45SensorInterface:
 
     def get_data(self, retries: int = 1) -> custom_types.SHT45SensorData:
         """Reads temperature and humidity in the air inlet"""
+
+        if self.simulate:
+            return custom_types.SHT45SensorData(
+                temperature=round(5.0 + 25.0 * random.random(), 2),
+                humidity=round(10.0 + 85.0 * random.random(), 2),
+            )
 
         # initialize output
         output = custom_types.SHT45SensorData(

--- a/sensor/src/hardware/sht45_sensor.py
+++ b/sensor/src/hardware/sht45_sensor.py
@@ -13,6 +13,7 @@ class SHT45SensorInterface:
         self,
         config: custom_types.Config,
         testing: bool = False,
+        simulate: bool = False,
     ) -> None:
         self.logger = utils.Logger(
             origin="sht45-sensor",

--- a/sensor/src/hardware/sht45_sensor.py
+++ b/sensor/src/hardware/sht45_sensor.py
@@ -24,6 +24,11 @@ class SHT45SensorInterface:
 
         self.logger.info("Starting initialization.")
 
+        if simulate:
+            self.sensor_connected = False
+            self.logger.info("Simulating SHT45 sensor.")
+            return
+
         # set up connection to SHT45 sensor
         self.sensor_connected = False
         for _ in range(2):

--- a/sensor/src/hardware/ups.py
+++ b/sensor/src/hardware/ups.py
@@ -32,9 +32,12 @@ class UPSInterface:
         self.battery_error_detected: Optional[bool] = None
         self.battery_above_voltage_threshold: Optional[bool] = None
 
-        if not simulate:
-            # use underlying pigpio library
-            self.pin_factory = utils.get_gpio_pin_factory()
+        if simulate:
+            self.logger.info("Simulating UPS.")
+            return
+
+        # use underlying pigpio library
+        self.pin_factory = utils.get_gpio_pin_factory()
 
         self.logger.info("Finished initialization")
 

--- a/sensor/src/hardware/valves.py
+++ b/sensor/src/hardware/valves.py
@@ -27,18 +27,21 @@ class ValveInterface:
         self.simulate = simulate
         self.logger.info("Starting initialization")
 
-        if not simulate:
-            # set up valve control pin connections
-            self.pin_factory = utils.get_gpio_pin_factory()
-            self.valves: dict[Literal[1, 2, 3, 4], gpiozero.OutputDevice] = {
-                1: gpiozero.OutputDevice(VALVE_PIN_1_OUT, pin_factory=self.pin_factory),
-                2: gpiozero.OutputDevice(VALVE_PIN_2_OUT, pin_factory=self.pin_factory),
-                3: gpiozero.OutputDevice(VALVE_PIN_3_OUT, pin_factory=self.pin_factory),
-                4: gpiozero.OutputDevice(VALVE_PIN_4_OUT, pin_factory=self.pin_factory),
-            }
-            self.active_input: Literal[1, 2, 3, 4] = self.config.measurement.valve_number
-            self.logger.info(f"Initialized with switching to valve: {self.active_input}")
-            self.set_active_input(self.active_input)
+        if self.simulate:
+            self.logger.info("Simulating valves.")
+            return
+
+        # set up valve control pin connections
+        self.pin_factory = utils.get_gpio_pin_factory()
+        self.valves: dict[Literal[1, 2, 3, 4], gpiozero.OutputDevice] = {
+            1: gpiozero.OutputDevice(VALVE_PIN_1_OUT, pin_factory=self.pin_factory),
+            2: gpiozero.OutputDevice(VALVE_PIN_2_OUT, pin_factory=self.pin_factory),
+            3: gpiozero.OutputDevice(VALVE_PIN_3_OUT, pin_factory=self.pin_factory),
+            4: gpiozero.OutputDevice(VALVE_PIN_4_OUT, pin_factory=self.pin_factory),
+        }
+        self.active_input: Literal[1, 2, 3, 4] = self.config.measurement.valve_number
+        self.logger.info(f"Initialized with switching to valve: {self.active_input}")
+        self.set_active_input(self.active_input)
 
         self.logger.info("Finished initialization")
 

--- a/sensor/src/hardware/valves.py
+++ b/sensor/src/hardware/valves.py
@@ -16,6 +16,7 @@ class ValveInterface:
         self,
         config: custom_types.Config,
         testing: bool = False,
+        simulate: bool = False,
     ) -> None:
         self.logger = utils.Logger(
             origin="valves",
@@ -23,19 +24,21 @@ class ValveInterface:
             write_to_file=(not testing),
         )
         self.config = config
+        self.simulate = simulate
         self.logger.info("Starting initialization")
 
-        # set up valve control pin connections
-        self.pin_factory = utils.get_gpio_pin_factory()
-        self.valves: dict[Literal[1, 2, 3, 4], gpiozero.OutputDevice] = {
-            1: gpiozero.OutputDevice(VALVE_PIN_1_OUT, pin_factory=self.pin_factory),
-            2: gpiozero.OutputDevice(VALVE_PIN_2_OUT, pin_factory=self.pin_factory),
-            3: gpiozero.OutputDevice(VALVE_PIN_3_OUT, pin_factory=self.pin_factory),
-            4: gpiozero.OutputDevice(VALVE_PIN_4_OUT, pin_factory=self.pin_factory),
-        }
-        self.active_input: Literal[1, 2, 3, 4] = self.config.measurement.valve_number
-        self.logger.info(f"Initialized with switching to valve: {self.active_input}")
-        self.set_active_input(self.active_input)
+        if not simulate:
+            # set up valve control pin connections
+            self.pin_factory = utils.get_gpio_pin_factory()
+            self.valves: dict[Literal[1, 2, 3, 4], gpiozero.OutputDevice] = {
+                1: gpiozero.OutputDevice(VALVE_PIN_1_OUT, pin_factory=self.pin_factory),
+                2: gpiozero.OutputDevice(VALVE_PIN_2_OUT, pin_factory=self.pin_factory),
+                3: gpiozero.OutputDevice(VALVE_PIN_3_OUT, pin_factory=self.pin_factory),
+                4: gpiozero.OutputDevice(VALVE_PIN_4_OUT, pin_factory=self.pin_factory),
+            }
+            self.active_input: Literal[1, 2, 3, 4] = self.config.measurement.valve_number
+            self.logger.info(f"Initialized with switching to valve: {self.active_input}")
+            self.set_active_input(self.active_input)
 
         self.logger.info("Finished initialization")
 
@@ -74,6 +77,9 @@ class ValveInterface:
 
     def teardown(self) -> None:
         """ends all hardware/system connections"""
+        if self.simulate:
+            return
+
         self.set_active_input(1)
         self.pin_factory.close()
 

--- a/sensor/src/hardware/wind_sensor.py
+++ b/sensor/src/hardware/wind_sensor.py
@@ -172,22 +172,25 @@ class WindSensorInterface:
         if self.device_status is not None:
             # only consider values less than 5 minutes old
             if (now - self.device_status.last_update_time) < 300:
-                if not self.simulate:
-                    if not (22 <= self.device_status.heating_voltage <= 26):
-                        raise WindSensorInterface.DeviceFailure(
-                            "the heating voltage is off by more than 2 volts"
-                            + f" ({self.device_status})"
-                        )
-                    if not (22 <= self.device_status.supply_voltage <= 26):
-                        raise WindSensorInterface.DeviceFailure(
-                            "the supply voltage is off by more than 2 volts"
-                            + f" ({self.device_status})"
-                        )
-                    if not (3.2 <= self.device_status.reference_voltage <= 4.0):
-                        raise WindSensorInterface.DeviceFailure(
-                            "the reference voltage is off by more than 0.4 volts"
-                            + f" ({self.device_status})"
-                        )
+                if self.simulate:
+                    self.logger.info("the wind sensor check doesn't report any errors")
+                    return
+
+                if not (22 <= self.device_status.heating_voltage <= 26):
+                    raise WindSensorInterface.DeviceFailure(
+                        "the heating voltage is off by more than 2 volts"
+                        + f" ({self.device_status})"
+                    )
+                if not (22 <= self.device_status.supply_voltage <= 26):
+                    raise WindSensorInterface.DeviceFailure(
+                        "the supply voltage is off by more than 2 volts"
+                        + f" ({self.device_status})"
+                    )
+                if not (3.2 <= self.device_status.reference_voltage <= 4.0):
+                    raise WindSensorInterface.DeviceFailure(
+                        "the reference voltage is off by more than 0.4 volts"
+                        + f" ({self.device_status})"
+                    )
 
                 self.logger.info("the wind sensor check doesn't report any errors")
         else:

--- a/sensor/src/hardware/wind_sensor.py
+++ b/sensor/src/hardware/wind_sensor.py
@@ -41,22 +41,25 @@ class WindSensorInterface:
         self.wind_measurement: Optional[custom_types.WindSensorData] = None
         self.device_status: Optional[custom_types.WindSensorStatus] = None
 
-        if not simulate:
-            # power pin to power up/down wind sensor
-            self.pin_factory = utils.get_gpio_pin_factory()
-            self.power_pin = gpiozero.OutputDevice(
-                pin=WIND_SENSOR_POWER_PIN_OUT,
-                pin_factory=self.pin_factory,
-            )
-            self.power_pin.on()
+        if self.simulate:
+            self.logger.info("Simulating wind sensor.")
+            return
 
-            # serial connection to receive data from wind sensor
-            self.wxt532_interface = utils.serial_interfaces.SerialOneDirectionalInterface(
-                port=WIND_SENSOR_SERIAL_PORT,
-                baudrate=19200,
-                encoding="cp1252",
-                line_ending="\r\n",
-            )
+        # power pin to power up/down wind sensor
+        self.pin_factory = utils.get_gpio_pin_factory()
+        self.power_pin = gpiozero.OutputDevice(
+            pin=WIND_SENSOR_POWER_PIN_OUT,
+            pin_factory=self.pin_factory,
+        )
+        self.power_pin.on()
+
+        # serial connection to receive data from wind sensor
+        self.wxt532_interface = utils.serial_interfaces.SerialOneDirectionalInterface(
+            port=WIND_SENSOR_SERIAL_PORT,
+            baudrate=19200,
+            encoding="cp1252",
+            line_ending="\r\n",
+        )
 
         self.logger.info("Finished initialization")
 

--- a/sensor/src/main.py
+++ b/sensor/src/main.py
@@ -26,8 +26,9 @@ def run() -> None:
     - Procedure: Measurements (CO2, Wind)
     - Check for configuration update
     """
+    simulate = os.environ.get("HERMES_MODE") == "simulate"
 
-    logger = utils.Logger(origin="main", print_to_console=True)
+    logger = utils.Logger(origin="main", print_to_console=simulate)
     logger.horizontal_line()
 
     try:
@@ -35,7 +36,6 @@ def run() -> None:
     except Exception as e:
         logger.exception(e, label="could not load local config.json")
         raise e
-    simulate = os.environ.get("HERMES_MODE") == "simulate"
 
     logger.info(
         f"Started new automation process with SW version {config.version} and PID {os.getpid()}.",

--- a/sensor/src/main.py
+++ b/sensor/src/main.py
@@ -27,7 +27,7 @@ def run() -> None:
     - Check for configuration update
     """
 
-    logger = utils.Logger(origin="main")
+    logger = utils.Logger(origin="main", print_to_console=True)
     logger.horizontal_line()
 
     try:
@@ -35,6 +35,7 @@ def run() -> None:
     except Exception as e:
         logger.exception(e, label="could not load local config.json")
         raise e
+    simulate = os.environ.get("HERMES_MODE") == "simulate"
 
     logger.info(
         f"Started new automation process with SW version {config.version} and PID {os.getpid()}.",
@@ -81,7 +82,8 @@ def run() -> None:
     logger.info("Initializing hardware interfaces.", config=config)
 
     try:
-        hardware_interface = hardware.HardwareInterface(config)
+        hardware_interface = hardware.HardwareInterface(config=config,
+                                                        simulate=simulate)
     except Exception as e:
         logger.exception(
             e, label="Could not initialize hardware interface.", config=config
@@ -105,7 +107,7 @@ def run() -> None:
     # initialize procedures
 
     # initialize config procedure
-    configuration_procedure = procedures.ConfigurationProcedure(config)
+    configuration_procedure = procedures.ConfigurationProcedure(config, simulate=simulate)
 
     # initialize procedures interacting with hardware:
     #   system_check:   logging system statistics and reporting hardware/system errors
@@ -116,16 +118,16 @@ def run() -> None:
 
     try:
         system_check_procedure = procedures.SystemCheckProcedure(
-            config, hardware_interface
+            config, hardware_interface, simulate=simulate
         )
         calibration_procedure = procedures.CalibrationProcedure(
-            config, hardware_interface
+            config, hardware_interface, simulate=simulate
         )
         wind_measurement_procedure = procedures.WindMeasurementProcedure(
-            config, hardware_interface
+            config, hardware_interface, simulate=simulate
         )
         co2_measurement_procedure = procedures.CO2MeasurementProcedure(
-            config, hardware_interface
+            config, hardware_interface, simulate=simulate
         )
     except Exception as e:
         logger.exception(e, label="could not initialize procedures", config=config)

--- a/sensor/src/procedures/calibration.py
+++ b/sensor/src/procedures/calibration.py
@@ -11,9 +11,11 @@ class CalibrationProcedure:
         self,
         config: custom_types.Config,
         hardware_interface: hardware.HardwareInterface,
+        simulate: bool = False,
     ) -> None:
         self.logger, self.config = utils.Logger(origin="calibration-procedure"), config
         self.hardware_interface = hardware_interface
+        self.simulate = simulate
 
         # state variables
         self.last_measurement_time: float = 0

--- a/sensor/src/procedures/configuration.py
+++ b/sensor/src/procedures/configuration.py
@@ -26,7 +26,7 @@ from src import custom_types, utils, hardware
 
 NAME = "hermes"
 REPOSITORY = f"tum-esm/{NAME}"
-ROOT_PATH = f"{os.environ['HOME']}/Documents/{NAME}"
+ROOT_PATH = os.environ.get('HERMES_DEPLOYMENT_ROOT_PATH', f"{os.environ['HOME']}/Documents/{NAME}")
 
 tarball_name: Callable[[str], str] = lambda version: f"v{version}.tar.gz"
 tarball_content_name: Callable[[str], str] = lambda version: f"{NAME}-{version}"
@@ -59,14 +59,14 @@ def restore_current_config() -> None:
 class ConfigurationProcedure:
     """runs when a config change has been requested"""
 
-    def __init__(self, config: custom_types.Config) -> None:
+    def __init__(self, config: custom_types.Config, simulate: bool = False) -> None:
         self.logger = utils.Logger(origin="configuration-procedure")
         self.config = config
         self._remove_old_venvs()
         self.message_queue = utils.MessageQueue()
 
         try:
-            self.hardware_interface = hardware.HardwareInterface(config)
+            self.hardware_interface = hardware.HardwareInterface(config, simulate=simulate)
         except Exception as e:
             self.logger.exception(
                 e, label="could not initialize hardware interface", config=config

--- a/sensor/src/procedures/measurement.py
+++ b/sensor/src/procedures/measurement.py
@@ -14,9 +14,11 @@ class WindMeasurementProcedure:
         self,
         config: custom_types.Config,
         hardware_interface: hardware.HardwareInterface,
+        simulate: bool = False,
     ) -> None:
         self.logger, self.config = utils.Logger(origin="measurement-procedure"), config
         self.hardware_interface = hardware_interface
+        self.simulate = simulate
 
         # state variables
         self.wind_data: Optional[custom_types.WindSensorData] = None
@@ -110,9 +112,11 @@ class CO2MeasurementProcedure:
         self,
         config: custom_types.Config,
         hardware_interface: hardware.HardwareInterface,
+        simulate: bool = False,
     ) -> None:
         self.logger, self.config = utils.Logger(origin="measurement-procedure"), config
         self.hardware_interface = hardware_interface
+        self.simulate = simulate
 
         # state variables
         self.active_air_inlet: Optional[Literal[1, 2, 3, 4]] = None

--- a/sensor/src/procedures/system_check.py
+++ b/sensor/src/procedures/system_check.py
@@ -12,10 +12,12 @@ class SystemCheckProcedure:
         self,
         config: custom_types.Config,
         hardware_interface: hardware.HardwareInterface,
+        simulate: bool = False,
     ) -> None:
         self.logger, self.config = utils.Logger(origin="system-check-procedure"), config
         self.hardware_interface = hardware_interface
         self.message_queue = utils.MessageQueue()
+        self.simulate = simulate
 
     def run(self) -> None:
         """runs system check procedure
@@ -32,7 +34,7 @@ class SystemCheckProcedure:
 
         mainboard_bme280_data = self.hardware_interface.mainboard_sensor.get_data()
         mainboard_temperature = mainboard_bme280_data.temperature
-        cpu_temperature = utils.get_cpu_temperature()
+        cpu_temperature = utils.get_cpu_temperature(self.simulate)
         self.logger.debug(
             f"mainboard temp. = {mainboard_temperature} °C, "
             + f"raspi cpu temp. = {cpu_temperature} °C"

--- a/sensor/src/utils/functions.py
+++ b/sensor/src/utils/functions.py
@@ -121,7 +121,9 @@ def get_random_string(length: int, forbidden: list[str] = []) -> str:
     return output
 
 
-def get_cpu_temperature() -> Optional[float]:
+def get_cpu_temperature(simulate: bool = False) -> Optional[float]:
+    if simulate:
+        return random.uniform(40, 60)
     s = os.popen("vcgencmd measure_temp").readline()
     return float(s.replace("temp=", "").replace("'C\n", ""))
 

--- a/sensor/src/utils/mqtt_connection.py
+++ b/sensor/src/utils/mqtt_connection.py
@@ -24,10 +24,14 @@ class MQTTConnection:
         self.client.username_pw_set(
             self.config.mqtt_username, self.config.mqtt_password
         )
+        # HERMES_MQTT_CERT_REQUIREMENTS = none (default), verify
+        ssl_cert_requirements = ssl.CERT_NONE if ((os.environ.get("HERMES_MQTT_CERT_REQUIREMENTS") or "none") == "none") \
+            else ssl.CERT_REQUIRED
+
         self.client.tls_set(
             certfile=None,
             keyfile=None,
-            cert_reqs=ssl.CERT_NONE,
+            cert_reqs=ssl_cert_requirements,
             tls_version=ssl.PROTOCOL_TLS_CLIENT,
         )
         self.client.connect(

--- a/sensor/src/utils/mqtt_connection.py
+++ b/sensor/src/utils/mqtt_connection.py
@@ -27,7 +27,7 @@ class MQTTConnection:
         self.client.tls_set(
             certfile=None,
             keyfile=None,
-            cert_reqs=ssl.CERT_REQUIRED,
+            cert_reqs=ssl.CERT_NONE,
             tls_version=ssl.PROTOCOL_TLS_CLIENT,
         )
         self.client.connect(

--- a/server/.env.example
+++ b/server/.env.example
@@ -12,3 +12,6 @@ HERMES_MQTT_URL=www.example.com
 HERMES_MQTT_PORT=8883
 HERMES_MQTT_IDENTIFIER=username
 HERMES_MQTT_PASSWORD=12345678
+
+# Execution mode (production / simulate)
+HERMES_MODE=production


### PR DESCRIPTION
# Simulate sensor software
This PR allows running the sensor project in a "simulate" mode, skipping interactions with sensors, raspberry pi libraries and I/O pins.
Instead, random data is generated to simulate a functioning sensor node, mainly for testing other systems like server/database infrastucture,  or network/message communication.
It can also become useful as part of CI-tests (given that the whole sensor project is also dockerizable)

### Changes
Changed are limited to the `sensor/src` folder, nearly all files are affected there.

### Warning
Despite extensive reviewing, it is possible for one of the 300+ changed lines to introduce a new bug in the sensor project, so it is highly advisable to test-run code based on these changes in a suitable test environment first before broad deployment.