### PR TITLE
added the "HERMES_" prefix to the sensor Dockerfile's hw-lockfile-path env var

### DIFF
--- a/sensor/docker/Dockerfile
+++ b/sensor/docker/Dockerfile
@@ -33,6 +33,6 @@ COPY tests ./tests
 COPY run_automation.py .
 COPY config/config.template.json ./config/config.json
 
-RUN echo 'HARDWARE_LOCKFILE_PATH="/root/hermes_hardware.lock"' > ./config/.env
+RUN echo 'HERMES_HARDWARE_LOCKFILE_PATH="/root/hermes_hardware.lock"' > ./config/.env
 
 ENTRYPOINT ["/root/.venv/bin/python3.9", "/root/run_automation.py"]


### PR DESCRIPTION
This only changes one line in one Dockerfile, it was missed in testing due to the env-var rewriting function fixing this issue automatically on launch