### PR TITLE
Feature/GitHub pages routing

### DIFF
--- a/.github/workflows/github-pages-deployment.yaml
+++ b/.github/workflows/github-pages-deployment.yaml
@@ -45,6 +45,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Build
+        env:
+          VITE_SERVER_URL: ${{ vars.VITE_SERVER_URL }}
+          VITE_URL_BASE_NAME: ${{ vars.VITE_URL_BASE_NAME }}
         run: npm run build
       - name: Create 404.html for github pages routing
         run: cp dashboard/dist/index.html dashboard/dist/404.html

--- a/.github/workflows/github-pages-deployment.yaml
+++ b/.github/workflows/github-pages-deployment.yaml
@@ -46,6 +46,8 @@ jobs:
         run: yarn install
       - name: Build
         run: npm run build
+      - name: Create 404.html for github pages routing
+        run: cp dashboard/dist/index.html dashboard/dist/404.html
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -8,10 +8,11 @@ import {
 import loginPage from "@/src/pages/login";
 import adminPage from "@/src/pages/admin";
 import sensorPage from "@/src/pages/sensor/[sensorName]";
+import {URL_BASE_NAME} from "@/src/utils/constants";
 
 export default function App() {
     return (
-        <BrowserRouter>
+        <BrowserRouter basename={URL_BASE_NAME}>
             <Layout>
                 <Routes>
                     <Route path="/" Component={indexPage} />

--- a/dashboard/src/utils/constants.ts
+++ b/dashboard/src/utils/constants.ts
@@ -5,3 +5,4 @@ if (!import.meta.env.VITE_SERVER_URL) {
 }
 
 export const SERVER_URL = import.meta.env.VITE_SERVER_URL;
+export const URL_BASE_NAME = import.meta.env.VITE_URL_BASE_NAME || '/';


### PR DESCRIPTION
This solves the routing-issues of the github pages deployment with two improvements:
 - the react-dom-router now allows for a basename to be configured through an environment variable, making it possible to route paths like `... .com/hermes/login`
 - the github workflow used for building and deploying the dashboard to github pages now
    - forwards the base-name and server-url environment variables to the build process
    - copies the `index.html` into a file called `404.html` , which is what github pages serves for all routes that are not "/" and for which there is not a `<path>.html` file present